### PR TITLE
fix build error in Chinese environment

### DIFF
--- a/src/test/java/org/apache/xmlgraphics/xmp/XMPParserTestCase.java
+++ b/src/test/java/org/apache/xmlgraphics/xmp/XMPParserTestCase.java
@@ -206,6 +206,6 @@ public class XMPParserTestCase {
         } catch (TransformerException e) {
             msg = e.getMessage();
         }
-        assertTrue(msg, msg.contains("access is not allowed"));
+        assertTrue(msg, msg.contains("accessExternalDTD"));
     }
 }


### PR DESCRIPTION
set system language to English

[ERROR] Failures: 
[ERROR]   XMPParserTestCase.testExternalDTD:209 org.xml.sax.SAXParseException; lineNumber: 3; columnNumber: 9; External Entity: Failed to read external document 'eval.xml', because 'http' access is not allowed due to restriction set by the accessExternalDTD property.                                                               
[INFO] 
[ERROR] Tests run: 189, Failures: 1, Errors: 0, Skipped: 4


set system language to other language (such as Chinese)

[ERROR] Failures: 
[ERROR]   XMPParserTestCase.testExternalDTD:209 org.xml.sax.SAXParseException; lineNumber: 3; columnNumber: 9; 外部实体: 无法读取外部文档 'eval.xml', 因为 accessExternalDTD 属性设置的限制导致不允许 'http' 访问。         
[INFO] 
[ERROR] Tests run: 189, Failures: 1, Errors: 0, Skipped: 4


We can find that the original judgment code has problems because it cannot adapt to other languages
    assertTrue(msg, msg.contains("access is not allowed"));
It is recommended to change to
    assertTrue(msg, msg.contains("accessExternalDTD"));
